### PR TITLE
Preserve alpha channel info (32bit image support)

### DIFF
--- a/jni/imageprocessing.c
+++ b/jni/imageprocessing.c
@@ -40,7 +40,7 @@ static void brightness(AndroidBitmapInfo* info, void* pixels, float brightnessVa
         blue = rgb_clamp((int)(blue * brightnessValue));
 
         // set the new pixel back in
-        line[xx] =
+        line[xx] = (line[xx] & 0xFF000000) |
           ((red << 16) & 0x00FF0000) |
           ((green << 8) & 0x0000FF00) |
           (blue & 0x000000FF);


### PR DESCRIPTION
The image is saved without alpha channel thus converted to 16bit. We need to preserve the alpha channel when saving the image.
